### PR TITLE
Update dockerfile to use newer docker image tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# Build runtime image
-FROM microsoft/aspnetcore-build:2.0 as builder
+FROM microsoft/dotnet:2.0-sdk as builder
 WORKDIR /app
 COPY . .
 RUN dotnet restore "Server/ProtoFiles/ProtoFiles.csproj"
@@ -15,7 +15,7 @@ FROM builder as publish
 RUN dotnet publish "Server/SubterfugeServer/SubterfugeServer.csproj" -o out -f netcoreapp2.0 -r linux-x64 --self-contained true -c Release
 
 # Build runtime image
-FROM microsoft/aspnetcore-build:2.0
+FROM microsoft/dotnet:2.0-sdk
 WORKDIR /app
 COPY --from=publish /app/Server/SubterfugeServer/out/ .
 EXPOSE 5000


### PR DESCRIPTION
# Description

Microsoft's docker image got pulled from the docker registry for some reason with no warning. Update the docker image tags to use docker images that actually work. Used [this article](https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-5.0) as a reference.

# Type of change

Bug fix

### Core
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] New dependencies/packages