### PR TITLE
Fix administrator ban endpoints

### DIFF
--- a/Core/Models/AccountModels.cs
+++ b/Core/Models/AccountModels.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-using System;
 using System.Collections.Generic;
 
 namespace SubterfugeCore.Models.GameEvents
@@ -49,7 +48,7 @@ namespace SubterfugeCore.Models.GameEvents
         public string? DeviceIdentifierSearch { get; set; } = "";
         public string? UserIdSearch { get; set; } = "";
         public UserClaim? RequireUserClaim { get; set; } = null;
-        public bool isBanned { get; set; } = false;
+        public bool? isBanned { get; set; } = null;
         public int pagination { get; set; } = 1;
     }
 

--- a/Core/Models/AdminModels.cs
+++ b/Core/Models/AdminModels.cs
@@ -68,6 +68,7 @@ namespace SubterfugeCore.Models.GameEvents
 
     public class IpBans
     {
+        public string Reason { get; set; }
         public string IpOrRegex { get; set; }
         public DateTime DateApplied { get; set; }
         public DateTime BannedUntil { get; set; }
@@ -85,6 +86,8 @@ namespace SubterfugeCore.Models.GameEvents
     public class BanIpRequest
     {
         public string DirectIpOrRegex { get; set; }
+        
+        public string Reason { get; set; }
         public DateTime Until { get; set; } = DateTime.Now.AddDays(1);
         public string AdminNotes { get; set; } = "";
     }

--- a/Core/Models/DatabaseModels.cs
+++ b/Core/Models/DatabaseModels.cs
@@ -21,8 +21,8 @@ namespace SubterfugeCore.Models.GameEvents
         // Administrative
         public DateTime DateCreated { get; set; }
         public DateTime BannedUntil { get; set; }
-        
-        public List<BanHistory> BanHistory { get; set; }
+
+        public List<AccountBan> BanHistory { get; set; } = new List<AccountBan>();
     }
 
     public class SimpleUser
@@ -69,7 +69,7 @@ namespace SubterfugeCore.Models.GameEvents
         DUPLICATE_EMAIL,
     }
 
-    public class BanHistory
+    public class AccountBan
     {
         public string Reason { get; set; }
         public string AdministratorNotes { get; set; }

--- a/Core/Models/Models.csproj.DotSettings
+++ b/Core/Models/Models.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp80</s:String></wpf:ResourceDictionary>

--- a/Server/SubterfugeDatabaseProvider/Models/DbIpBan.cs
+++ b/Server/SubterfugeDatabaseProvider/Models/DbIpBan.cs
@@ -8,12 +8,14 @@ public class DbIpBan
     public DateTime DateApplied { get; set; } = DateTime.UtcNow;
     public string IpAddressOrRegex { get; set; }
     public DateTime BannedUntil { get; set; }
+    public string Reason { get; set; }
     public string AdminNotes { get; set; }
 
     public IpBans ToIpBan()
     {
         return new IpBans()
         {
+            Reason = Reason,
             AdminNotes = AdminNotes,
             BannedUntil = BannedUntil,
             DateApplied = DateApplied,

--- a/Server/SubterfugeDatabaseProvider/Models/DbUserModel.cs
+++ b/Server/SubterfugeDatabaseProvider/Models/DbUserModel.cs
@@ -70,6 +70,7 @@ public class DbUserModel
             PushNotificationIdentifier = PushNotificationIdentifier,
             DeviceType = DeviceType,
             MultiboxAccounts = MultiboxAccounts,
+            BanHistory = BanHistory,
         };
     }
 
@@ -89,12 +90,4 @@ public class DbUserModel
     {
         return Claims.Contains(claim);
     }
-}
-
-public class AccountBan
-{
-    public string Reason { get; set; }
-    public string AdministratorNotes { get; set; }
-    public DateTime DateExpires { get; set; }
-    public DateTime DateApplied { get; set; } = DateTime.UtcNow;
 }

--- a/Server/SubterfugeRestApiServer/Controllers/account/UserController.cs
+++ b/Server/SubterfugeRestApiServer/Controllers/account/UserController.cs
@@ -146,15 +146,18 @@ public class UserController : ControllerBase, ISubterfugeAccountApi
             // Create a filter that require the claim to exist in the user claims
             query = query.Where(it => it.Claims.Any(it => it == request.RequireUserClaim));
 
-        if (request.isBanned)
+        if (request.isBanned != null)
         {
-            // Create a filter that only gets models with a 'BannedUntil' date after today.
-            query = query.Where(it => it.BannedUntil > DateTime.UtcNow);
-        }
-        else
-        {
-            // Create a filter that only gets models with a 'BannedUntil' date before today.
-            query = query.Where(it => it.BannedUntil <= DateTime.UtcNow);
+            if ((bool)request.isBanned)
+            {
+                // Create a filter that only gets models with a 'BannedUntil' date after today.
+                query = query.Where(it => it.BannedUntil > DateTime.UtcNow);
+            }
+            else
+            {
+                // Create a filter that only gets models with a 'BannedUntil' date before today.
+                query = query.Where(it => it.BannedUntil <= DateTime.UtcNow);
+            }
         }
 
         var matchingUsers = (await query

--- a/Server/SubterfugeRestApiServer/Controllers/admin/ServerAdminController.cs
+++ b/Server/SubterfugeRestApiServer/Controllers/admin/ServerAdminController.cs
@@ -122,7 +122,7 @@ public class SubterfugeAdminController : ControllerBase, ISubterfugeAdminApi
 
     [HttpPost]
     [Route("banPlayer")]
-    public async Task<NetworkResponse> BanPlayer(BanPlayerRequest banPlayerRequest)
+    public async Task<NetworkResponse> BanPlayer([FromBody] BanPlayerRequest banPlayerRequest)
     {
         DbUserModel? dbUserModel = HttpContext.Items["User"] as DbUserModel;
         if (dbUserModel == null)
@@ -161,7 +161,7 @@ public class SubterfugeAdminController : ControllerBase, ISubterfugeAdminApi
     [Authorize(Roles = "Administrator")]
     [HttpPost]
     [Route("banIp")]
-    public async Task<NetworkResponse> BanIp(BanIpRequest banIpRequest)
+    public async Task<NetworkResponse> BanIp([FromBody] BanIpRequest banIpRequest)
     {
         DbUserModel? dbUserModel = HttpContext.Items["User"] as DbUserModel;
         if (dbUserModel == null)
@@ -172,6 +172,7 @@ public class SubterfugeAdminController : ControllerBase, ISubterfugeAdminApi
 
         var newBan = new DbIpBan()
         {
+            Reason = banIpRequest.Reason,
             BannedUntil = banIpRequest.Until,
             IpAddressOrRegex = banIpRequest.DirectIpOrRegex,
             AdminNotes = banIpRequest.AdminNotes,


### PR DESCRIPTION
# Description
The administrator ban endpoints were not properly reading data from the request body. Updated these endpoints to accurately read the data that was being reported from these endpoints.