### PR TITLE
Fix MapGeneratorTest when running alone

### DIFF
--- a/Core/SubterfugeCoreTest/MapGenerator.test.cs
+++ b/Core/SubterfugeCoreTest/MapGenerator.test.cs
@@ -30,6 +30,8 @@ namespace Subterfuge.Remake.Test
         public void Setup()
         {
             _timeMachine = new TimeMachine(new GameState(players));
+            GameConfiguration config = new TestUtils().GetDefaultGameConfiguration(players);
+            new Game(config);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes the `MapGeneratorTest` class when attempting to run the tests in this class without running them as part of the entire suite. Instantiating a new `Game` creates the `SeededRandom` to no `NullPointerExceptions` are thrown