### PR TITLE
Use latest ubuntu image to fix pipelines

### DIFF
--- a/.github/workflows/DeployRelease.yml
+++ b/.github/workflows/DeployRelease.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "build"
   unitTest:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     # The container image to pull from dockerhub
     container: mcr.microsoft.com/dotnet/sdk:7.0
 

--- a/.github/workflows/TestDll.yml
+++ b/.github/workflows/TestDll.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "build"
   unitTest:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     # The container image to pull
     container: mcr.microsoft.com/dotnet/sdk:7.0
 
@@ -29,7 +29,7 @@ jobs:
       run: dotnet test "Core/SubterfugeCoreTest/SubterfugeCoreTest.csproj"
   # A step to build docfx documents using a differnt container with docfx installed
   gen-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container: erothejoker/docker-docfx:latest
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/TestServer.yml
+++ b/.github/workflows/TestServer.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "build"
   testServer:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Github recently deprecated `ubuntu-18.04` pipelines.  Instead bump them to use the latest version.

https://stackoverflow.com/questions/70959954/error-waiting-for-a-runner-to-pick-up-this-job-using-github-actions

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
