### PR TITLE
Issue 126

### DIFF
--- a/Core/SubterfugeCore/Core/Entities/Positions/Outpost.cs
+++ b/Core/SubterfugeCore/Core/Entities/Positions/Outpost.cs
@@ -26,7 +26,10 @@ namespace Subterfuge.Remake.Core.Entities.Positions
             Player outpostOwner = null,
             float visionRadius = Constants.BaseOutpostVisionRadius
         ) {
-            AddComponent(new DrillerCarrier(this, Constants.InitialDrillersPerOutpost, outpostOwner));
+            // Ensure unowned outposts start with 0 dillers
+            int initialDrillers = outpostOwner != null ? Constants.InitialDrillersPerOutpost : 0;
+
+            AddComponent(new DrillerCarrier(this, initialDrillers, outpostOwner));
             AddComponent(new SpeedManager(this, 0.0f));
             AddComponent(new PositionManager(this, outpostStartPosition, new GameTick(), timeMachine));
             AddComponent(new SpecialistManager(this, 100));

--- a/Core/SubterfugeCore/Core/GameEvents/Combat/CombatEvents/SpecialCombatEvents/ResourceProductionEvent.cs
+++ b/Core/SubterfugeCore/Core/GameEvents/Combat/CombatEvents/SpecialCombatEvents/ResourceProductionEvent.cs
@@ -32,13 +32,29 @@ namespace Subterfuge.Remake.Core.GameEvents.Combat.CombatEvents
             switch (ResourceType)
             {
                 case ProducedResourceType.Driller:
-                    ValueProduced = ProductionLocation.GetComponent<DrillerCarrier>().AlterDrillers(GetNextProductionAmount(timeMachine.GetState()));
+                    // Ensure unowned outposts do not produce drillers
+                    if (ProductionLocation.GetComponent<DrillerCarrier>().GetOwner() == null)
+                    {
+                        ValueProduced = 0;
+                    }
+                    else
+                    {
+                        ValueProduced = ProductionLocation.GetComponent<DrillerCarrier>().AlterDrillers(GetNextProductionAmount(timeMachine.GetState()));
+                    }
                     break;
                 case ProducedResourceType.Neptunium:
                     ValueProduced = ProductionLocation.GetComponent<DrillerCarrier>().GetOwner().AlterNeptunium(GetNextProductionAmount(timeMachine.GetState()));
                     break;
                 case ProducedResourceType.Shield:
-                    ValueProduced = ProductionLocation.GetComponent<ShieldManager>().AlterShields(GetNextProductionAmount(timeMachine.GetState()));
+                    // Ensure unowned outposts do not produce shields
+                    if (ProductionLocation.GetComponent<DrillerCarrier>().GetOwner() == null)
+                    {
+                        ValueProduced = 0;
+                    }
+                    else
+                    {
+                        ValueProduced = ProductionLocation.GetComponent<ShieldManager>().AlterShields(GetNextProductionAmount(timeMachine.GetState()));
+                    }
                     break;
             }
 

--- a/Core/SubterfugeCoreTest/MapGenerator.test.cs
+++ b/Core/SubterfugeCoreTest/MapGenerator.test.cs
@@ -167,7 +167,7 @@ namespace Subterfuge.Remake.Test
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             // Advance the time forward 100 ticks to allow time for shield generation
-            _timeMachine.Advance(100);
+            _timeMachine.Advance(Constants.BASE_SHIELD_REGENERATION_TICKS);
 
             // Check that each unowned outpost has not generated shields
             foreach (Outpost outpost in generatedOutposts.Where(x => x.GetComponent<DrillerCarrier>().GetOwner() == null))
@@ -191,8 +191,8 @@ namespace Subterfuge.Remake.Test
             MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
-            // Advance the time forward 100 ticks to allow time for driller production
-            _timeMachine.Advance(100);
+            // Advance the time forward until next production
+            _timeMachine.Advance(Constants.TicksPerProduction);
 
             // Check that each unowned outpost has not produced drillers
             foreach (Outpost outpost in generatedOutposts.Where(x => x.GetComponent<DrillerCarrier>().GetOwner() == null))

--- a/Core/SubterfugeCoreTest/MapGenerator.test.cs
+++ b/Core/SubterfugeCoreTest/MapGenerator.test.cs
@@ -166,7 +166,7 @@ namespace Subterfuge.Remake.Test
             MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
-            // Advance the time forward 100 ticks to allow time for shield generation
+            // Advance the time forward until next shield production
             _timeMachine.Advance(Constants.BASE_SHIELD_REGENERATION_TICKS);
 
             // Check that each unowned outpost has not generated shields

--- a/Core/SubterfugeCoreTest/MapGenerator.test.cs
+++ b/Core/SubterfugeCoreTest/MapGenerator.test.cs
@@ -128,7 +128,79 @@ namespace Subterfuge.Remake.Test
                 Assert.AreEqual(config.MapConfiguration.OutpostsPerPlayer, keyValuePair.Value);   
             }
         }
-        
+
+        [TestMethod]
+        public void UnownedOutpostsHaveNoDrillers()
+        {
+            GameConfiguration config = _testUtils.GetDefaultGameConfiguration(players);
+            Assert.IsNotNull(config);
+            Random rand = new Random(DateTime.UtcNow.Millisecond);
+            config.MapConfiguration.Seed = rand.Next();
+            config.MapConfiguration.DormantsPerPlayer = 3;
+            config.MapConfiguration.MaximumOutpostDistance = 100;
+            config.MapConfiguration.MinimumOutpostDistance = 5;
+            config.MapConfiguration.OutpostsPerPlayer = 7;
+
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            List<Outpost> generatedOutposts = generator.GenerateMap();
+
+            // Loop through all unowned outpost and verify that the driller count is 0 for each
+            foreach (Outpost outpost in generatedOutposts.Where(x => x.GetComponent<DrillerCarrier>().GetOwner() == null))
+            {
+                Assert.AreEqual(0, outpost.GetComponent<DrillerCarrier>().GetDrillerCount());
+            }
+        }
+
+        [TestMethod]
+        public void UnownedOutpostsHaveNoShieldGeneration()
+        {
+            GameConfiguration config = _testUtils.GetDefaultGameConfiguration(players);
+            Assert.IsNotNull(config);
+            Random rand = new Random(DateTime.UtcNow.Millisecond);
+            config.MapConfiguration.Seed = rand.Next();
+            config.MapConfiguration.DormantsPerPlayer = 3;
+            config.MapConfiguration.MaximumOutpostDistance = 100;
+            config.MapConfiguration.MinimumOutpostDistance = 5;
+            config.MapConfiguration.OutpostsPerPlayer = 7;
+
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            List<Outpost> generatedOutposts = generator.GenerateMap();
+
+            // Advance the time forward 100 ticks to allow time for shield generation
+            _timeMachine.Advance(100);
+
+            // Check that each unowned outpost has not generated shields
+            foreach (Outpost outpost in generatedOutposts.Where(x => x.GetComponent<DrillerCarrier>().GetOwner() == null))
+            {
+                Assert.AreEqual(0, outpost.GetComponent<ShieldManager>().GetShields());
+            }
+        }
+
+        [TestMethod]
+        public void UnownedOutpostsHaveNoDrillerProduction()
+        {
+            GameConfiguration config = _testUtils.GetDefaultGameConfiguration(players);
+            Assert.IsNotNull(config);
+            Random rand = new Random(DateTime.UtcNow.Millisecond);
+            config.MapConfiguration.Seed = rand.Next();
+            config.MapConfiguration.DormantsPerPlayer = 3;
+            config.MapConfiguration.MaximumOutpostDistance = 100;
+            config.MapConfiguration.MinimumOutpostDistance = 5;
+            config.MapConfiguration.OutpostsPerPlayer = 7;
+
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            List<Outpost> generatedOutposts = generator.GenerateMap();
+
+            // Advance the time forward 100 ticks to allow time for driller production
+            _timeMachine.Advance(100);
+
+            // Check that each unowned outpost has not produced drillers
+            foreach (Outpost outpost in generatedOutposts.Where(x => x.GetComponent<DrillerCarrier>().GetOwner() == null))
+            {
+                Assert.AreEqual(0, outpost.GetComponent<DrillerCarrier>().GetDrillerCount());
+            }
+        }
+
         [TestMethod]
         public void AllPlayersHaveAQueen()
         {


### PR DESCRIPTION
Outpost.cs:
Initialize unowned outposts with 0 drillers

ResourceProductionEvent.cs:
Disable shield and driller production for unowned outposts

MapGenerator.test.cs:
Add 3 tests:
1. Unowned outposts have no drillers at the start of the game
2. Unowned outposts don't generate shields
3. Unowned outposts don't generate drillers

# Description

<!-- 
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context. This can be helped by linking to any related issue (ex: Fixes #1).
Be as detailed as possible and be sure to indicate how this change will effect downstream users.

Also list any new dependencies/packages that are required for this change.
-->

# Type of change

<!-- Please select options that are relevant. -->

### CLI
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] New dependencies/packages

### Core
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] New dependencies/packages

# Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] I have created automated tests for any new features
- [x] All automated tests pass
- [ ] I have performed manual tests


# Checklist:

<!-- Please make sure the following have been performed. -->
<!-- If they have not yet been performed, leave them unchecked (and/or) title your PR with "WIP: ". -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code according to C# standards
- [ ] I have made corresponding changes to the README (if required)
- [ ] I have added/updated articles in the documentation
- [x] My changes generate no new warnings

<!-- 
Does this PR include breaking changes to downstream modules?
The backend and Unity repositories make use of the DLL that is generated by this repository.
If any breaking changes are made, ensure that the backend and unity developers are aware of the changes.
-->

# Test run output:
```
Subterfuge.Remake.Test.MapGeneratorTest.UnownedOutpostsHaveNoDrillers:
    Outcome: Passed
Subterfuge.Remake.Test.MapGeneratorTest.UnownedOutpostsHaveNoShieldGeneration:
    Outcome: Passed
Subterfuge.Remake.Test.MapGeneratorTest.UnownedOutpostsHaveNoDrillerProduction:
    Outcome: Passed
```

<!-- Any questions you are still wondering about or discussions to be had about the changes.
You can also include specific areas/files you would like reviewed or commented on. -->