### PR TITLE
Bare Games

### DIFF
--- a/Core/Models/Network/DatabaseModels.cs
+++ b/Core/Models/Network/DatabaseModels.cs
@@ -26,8 +26,8 @@ namespace Subterfuge.Remake.Api.Network
 
     public class SimpleUser
     {
-        public string Id { get; set; }
-        public string Username { get; set; }
+        public string Id { get; set; } = "Debug";
+        public string Username { get; set; } = "Debug";
 
         public User ToUser()
         {

--- a/Core/Models/Network/GameLobbyModels.cs
+++ b/Core/Models/Network/GameLobbyModels.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace Subterfuge.Remake.Api.Network
 {
@@ -13,19 +14,22 @@ namespace Subterfuge.Remake.Api.Network
         Expired = 5,
     }
     
-    public class GameConfiguration {
-        public string Id { get; set; }
-        public RoomStatus RoomStatus { get; set; }
-        public User Creator { get; set; }
-        public GameSettings GameSettings { get; set; }
-        public MapConfiguration MapConfiguration { get; set; }
-        public string RoomName { get; set; }
+    public class GameConfiguration
+    {
+        public string Id { get; set; } = "Debug";
+        public RoomStatus RoomStatus { get; set; } = RoomStatus.Ongoing;
+        public User Creator { get; set; } = new SimpleUser().ToUser();
+        public GameSettings GameSettings { get; set; } = new GameSettings();
+        public MapConfiguration MapConfiguration { get; set; } = new MapConfiguration();
+        public string RoomName { get; set; } = "Default";
         public GameVersion GameVersion { get; set; } = GameVersion.ALPHA01;
-        public DateTime TimeCreated { get; set; }
-        public DateTime TimeStarted { get; set; }
+        public DateTime TimeCreated { get; set; } = DateTime.UtcNow;
+        public DateTime TimeStarted { get; set; } = DateTime.UtcNow;
         public DateTime ExpiresAt { get; set; } = DateTime.MaxValue;
-        public List<User> PlayersInLobby { get; set; }
-        public Dictionary<string, List<SpecialistTypeId>> PlayerSpecialistDecks { get; set; }
+        public List<User> PlayersInLobby { get; set; } = new List<User>() { new SimpleUser() { Id = "1", Username = "Test1"}.ToUser(), new SimpleUser(){ Id = "2", Username = "Test2"}.ToUser() };
+
+        public Dictionary<string, List<SpecialistTypeId>> PlayerSpecialistDecks { get; set; } =
+            new Dictionary<string, List<SpecialistTypeId>>();
     }
     
     public enum GameVersion
@@ -36,29 +40,29 @@ namespace Subterfuge.Remake.Api.Network
 
     public class GameSettings
     {
-        public double MinutesPerTick { get; set; }
-        public Goal Goal { get; set; }
-        public Boolean IsRanked { get; set; }
-        public Boolean IsAnonymous { get; set; }
-        public Boolean IsPrivate { get; set; }
-        public int MaxPlayers { get; set; }
+        public double MinutesPerTick { get; set; } = 10;
+        public Goal Goal { get; set; } = Goal.Domination;
+        public Boolean IsRanked { get; set; } = false;
+        public Boolean IsAnonymous { get; set; } = true;
+        public Boolean IsPrivate { get; set; } = false;
+        public int MaxPlayers { get; set; } = 2;
     }
 
     public class MapConfiguration
     {
-        public int Seed { get; set; }
-        public int OutpostsPerPlayer { get; set; }
-        public int MinimumOutpostDistance { get; set; }
-        public int MaximumOutpostDistance { get; set; }
-        public int DormantsPerPlayer { get; set; }
-        public OutpostDistribution OutpostDistribution { get; set; }
+        public int Seed { get; set; } = 1234;
+        public int OutpostsPerPlayer { get; set; } = 1;
+        public int MinimumOutpostDistance { get; set; } = 50;
+        public int MaximumOutpostDistance { get; set; } = 200;
+        public int DormantsPerPlayer { get; set; } = 4;
+        public OutpostDistribution OutpostDistribution { get; set; } = new OutpostDistribution();
     }
 
     public class OutpostDistribution
     {
-        public float GeneratorWeight { get; set; }
-        public float FactoryWeight { get; set; }
-        public float WatchtowerWeight { get; set; }
+        public float GeneratorWeight { get; set; } = 0.45f;
+        public float FactoryWeight { get; set; } = 0.45f;
+        public float WatchtowerWeight { get; set; } = 0.1f;
     }
 
     public enum Goal

--- a/Core/Models/Network/GameLobbyModels.cs
+++ b/Core/Models/Network/GameLobbyModels.cs
@@ -26,7 +26,7 @@ namespace Subterfuge.Remake.Api.Network
         public DateTime TimeCreated { get; set; } = DateTime.UtcNow;
         public DateTime TimeStarted { get; set; } = DateTime.UtcNow;
         public DateTime ExpiresAt { get; set; } = DateTime.MaxValue;
-        public List<User> PlayersInLobby { get; set; } = new List<User>() { new SimpleUser() { Id = "1", Username = "Test1"}.ToUser(), new SimpleUser(){ Id = "2", Username = "Test2"}.ToUser() };
+        public List<User> PlayersInLobby { get; set; } = new List<User>() { };
 
         public Dictionary<string, List<SpecialistTypeId>> PlayerSpecialistDecks { get; set; } =
             new Dictionary<string, List<SpecialistTypeId>>();

--- a/Core/SubterfugeCore/Core/Entities/Components/PositionManager.cs
+++ b/Core/SubterfugeCore/Core/Entities/Components/PositionManager.cs
@@ -115,6 +115,14 @@ namespace Subterfuge.Remake.Core.Entities.Components
                             CombatEvent = combat,
                         });
                         
+                        // Also include any defensive combat events
+                        entityToFight.GetComponent<PositionManager>().OnRegisterCombatEffects?.Invoke(this, new OnRegisterCombatEventArgs()
+                        {
+                            Direction = onTick.Direction,
+                            CurrentState = timeMachine.GetState(),
+                            CombatEvent = combat,
+                        });
+                        
                         timeMachine.AddEvent(combat);
                         localCombatEvents.Add(combat);
                     }

--- a/Core/SubterfugeCore/Core/Entities/Components/SpecialistManager.cs
+++ b/Core/SubterfugeCore/Core/Entities/Components/SpecialistManager.cs
@@ -194,10 +194,10 @@ namespace Subterfuge.Remake.Core.Entities.Components
         /// <param name="specialistIds">List of specialist Ids to transfer</param>
         public bool TransferSpecialistsById(SpecialistManager destinationSpecialistManager, List<string> specialistIds, TimeMachine timeMachine)
         {
-            var specialistsMatchingId = _specialists.Where(it => specialistIds.Contains(it.GetId())).ToList();
+            var specialistsMatchingId = _specialists.Where(it => specialistIds.Contains(it.GetSpecialistId().ToString())).ToList();
             if (destinationSpecialistManager.CanAddSpecialists(specialistsMatchingId.Count))
             {
-                _specialists = _specialists.Where(it => !specialistIds.Contains(it.GetId())).ToList();
+                _specialists = _specialists.Where(it => !specialistIds.Contains(it.GetSpecialistId().ToString())).ToList();
                 destinationSpecialistManager._specialists.AddRange(specialistsMatchingId);
                 
                 specialistsMatchingId.ForEach(spec =>

--- a/Core/SubterfugeCore/Core/Entities/EntityData.cs
+++ b/Core/SubterfugeCore/Core/Entities/EntityData.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Subterfuge.Remake.Api.Network;
+using Subterfuge.Remake.Core.Players;
+
+namespace Subterfuge.Remake.Core.Entities
+{
+    public class EntityData
+    {
+        public int DrillerCount { get; set; } = 0;
+        public int ShieldCount { get; set; } = 0;
+        public Player Owner { get; set; } = null;
+        public List<SpecialistTypeId> Specialists
+        {
+            get;
+            set;
+        } = null;
+        
+    }
+}

--- a/Core/SubterfugeCore/Core/Entities/Specialists/Heroes/Queen.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/Heroes/Queen.cs
@@ -7,7 +7,7 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Heroes
 {
     public class Queen: Specialist
     {
-        private int shieldDelta = 25;
+        public static int SHIELD_PROVIDED = 25;
         
         public Queen(Player owner) : base(owner, true)
         {
@@ -18,7 +18,7 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Heroes
             if (!this._isCaptured)
             {
                 entity.GetComponent<SpecialistManager>().AllowHireFromLocation();
-                entity.GetComponent<ShieldManager>().AlterShieldCapacity(shieldDelta);
+                entity.GetComponent<ShieldManager>().AlterShieldCapacity(SHIELD_PROVIDED);
             }
         }
 
@@ -28,7 +28,7 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Heroes
             if (!this._isCaptured)
             {
                 entity.GetComponent<SpecialistManager>().DisallowHireFromLocation();
-                entity.GetComponent<ShieldManager>().AlterShieldCapacity(shieldDelta * -1);
+                entity.GetComponent<ShieldManager>().AlterShieldCapacity(SHIELD_PROVIDED * -1);
             }
         }
 
@@ -47,7 +47,7 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Heroes
 
         public override string GetDescription()
         {
-            return $"Adds ${shieldDelta} shields to the Queen's Location. If the Queen dies, the owner is eliminated.";
+            return $"Adds ${SHIELD_PROVIDED} shields to the Queen's Location. If the Queen dies, the owner is eliminated.";
         }
     }
 }

--- a/Core/SubterfugeCore/Core/Entities/Specialists/Specialist.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/Specialist.cs
@@ -14,12 +14,6 @@ namespace Subterfuge.Remake.Core.Entities.Specialists
     public abstract class Specialist
     {
         /// <summary>
-        /// The name of the specialist
-        /// </summary>
-        /// TODO: Generate the id from a known seed.
-        private readonly string _specialistId = Guid.NewGuid().ToString();
-        
-        /// <summary>
         /// The player who owns the specialist
         /// </summary>
         protected Player _owner;
@@ -48,16 +42,6 @@ namespace Subterfuge.Remake.Core.Entities.Specialists
         ) {
             _owner = owner;
             IsHero = isHero;
-        }
-
-        /// <summary>
-        /// Returns the specialist id.
-        /// </summary>
-        /// <returns>The specialist's id</returns>
-        public string GetId()
-        {
-            // TODO: Do something else here.
-            return GetSpecialistId().ToString();
         }
 
         /// <summary>

--- a/Core/SubterfugeCore/Core/Entities/Specialists/SpecialistFactory.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/SpecialistFactory.cs
@@ -28,6 +28,10 @@ namespace Subterfuge.Remake.Core.Entities.Specialists
                     return new Smuggler(owner);
                 case SpecialistTypeId.Veteran:
                     return new Veteran(owner);
+                case SpecialistTypeId.Martyr:
+                    return new Martyr(owner);
+                case SpecialistTypeId.Theif:
+                    return new Theif(owner);
                 default:
                     return null;
             }

--- a/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Infiltrator.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Infiltrator.cs
@@ -51,8 +51,8 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Specialists
             
             registerCombatEventArgs.CombatEvent.AddEffectToCombat(new AlterShieldEffect(
                 registerCombatEventArgs.CombatEvent,
-                friendlyEntity,
-                GetShieldDelta(enemyEntity)
+                enemyEntity,
+                GetShieldDelta(enemyEntity) * -1
             ));
 
             if (GetLevel() >= 2)

--- a/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Martyr.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Martyr.cs
@@ -15,7 +15,7 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Specialists
 
         public override void ArriveAtLocation(IEntity entity, TimeMachine timeMachine)
         {
-            if (_isCaptured)
+            if (!_isCaptured)
             {
                 entity.GetComponent<PositionManager>().OnRegisterCombatEffects += ExplodeOnCombatEffects;
             }
@@ -23,7 +23,7 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Specialists
 
         public override void LeaveLocation(IEntity entity, TimeMachine timeMachine)
         {
-            if (_isCaptured)
+            if (!_isCaptured)
             {
                 entity.GetComponent<PositionManager>().OnRegisterCombatEffects -= ExplodeOnCombatEffects;
             }

--- a/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Theif.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Theif.cs
@@ -51,8 +51,8 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Specialists
             combatEventArgs.CombatEvent.AddEffectToCombat(new AlterDrillerEffect(
                 combatEventArgs.CombatEvent,
                 friendlyEntity,
-                (int)(enemyCarrier.GetDrillerCount() * _stealPerLevel[_level]),
-                (int)(enemyCarrier.GetDrillerCount() * _stealPerLevel[_level] * -1)
+                (int)(enemyCarrier.GetDrillerCount() * _stealPerLevel[_level - 1]),
+                (int)(enemyCarrier.GetDrillerCount() * _stealPerLevel[_level - 1] * -1)
             ));
         }
 

--- a/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Veteran.cs
+++ b/Core/SubterfugeCore/Core/Entities/Specialists/Specialists/Veteran.cs
@@ -53,13 +53,13 @@ namespace Subterfuge.Remake.Core.Entities.Specialists.Specialists
         {
             var friendlyEntity = eventArgs.CombatEvent.GetEntityOwnedBy(_owner);
             var friendlyDrillers = friendlyEntity.GetComponent<DrillerCarrier>().GetDrillerCount();
-            var extraDrillers = (int)(ExtraDrillersPerLevel[_level] * friendlyDrillers);
+            var extraDrillers = (int)(ExtraDrillersPerLevel[_level - 1] * friendlyDrillers);
             
             eventArgs.CombatEvent.AddEffectToCombat(new AlterDrillerEffect(
                 eventArgs.CombatEvent,
                 friendlyEntity,
                 0,
-                -1 * (drillersPerLevel[_level] + extraDrillers)
+                -1 * (drillersPerLevel[_level - 1] + extraDrillers)
             ));
         }
     }

--- a/Core/SubterfugeCore/Core/Game.cs
+++ b/Core/SubterfugeCore/Core/Game.cs
@@ -52,6 +52,11 @@ namespace Subterfuge.Remake.Core
         private Game()
         {
             GameConfiguration = new GameConfiguration();
+            GameConfiguration.PlayersInLobby = new List<User>()
+            {
+                new SimpleUser() { Id = "1", Username = "Test1" }.ToUser(),
+                new SimpleUser() { Id = "2", Username = "Test1" }.ToUser(),
+            };
             SetupGameFromConfiguration(GameConfiguration, false);
         }
 

--- a/Core/SubterfugeCore/Core/GameEvents/Combat/CombatEvents/CombatResolve/FriendlyCombatResolution.cs
+++ b/Core/SubterfugeCore/Core/GameEvents/Combat/CombatEvents/CombatResolve/FriendlyCombatResolution.cs
@@ -43,7 +43,7 @@ namespace Subterfuge.Remake.Core.GameEvents.Combat.CombatEvents
         {
             _outpost.GetComponent<DrillerCarrier>().AlterDrillers(_drillersTransferred * -1);
             _outpost.GetComponent<SpecialistManager>()
-                .TransferSpecialistsById(_sub.GetComponent<SpecialistManager>(), _specialistsTransferred.Select(it => it.GetId()).ToList(), timeMachine);
+                .TransferSpecialistsById(_sub.GetComponent<SpecialistManager>(), _specialistsTransferred.Select(it => it.GetSpecialistId().ToString()).ToList(), timeMachine);
             timeMachine.GetState().AddSub(_sub);
             return true;
         }

--- a/Core/SubterfugeCore/Core/GameEvents/Combat/CombatEvents/NaturalCombatEvents/CombatOwnershipTransferEffect.cs
+++ b/Core/SubterfugeCore/Core/GameEvents/Combat/CombatEvents/NaturalCombatEvents/CombatOwnershipTransferEffect.cs
@@ -81,7 +81,7 @@ namespace Subterfuge.Remake.Core.GameEvents.Combat.CombatEvents
                 {
                     // Put specialists back on the sub.
                     _outpost.GetComponent<SpecialistManager>()
-                        .TransferSpecialistsById(_sub.GetComponent<SpecialistManager>(), specialistsTransferred.Select(it => it.GetId()).ToList(), timeMachine);
+                        .TransferSpecialistsById(_sub.GetComponent<SpecialistManager>(), specialistsTransferred.Select(it => it.GetSpecialistId().ToString()).ToList(), timeMachine);
                     
                     // Put drillers back on the sub.
                     _sub.GetComponent<DrillerCarrier>().AlterDrillers(drillersTransferred);
@@ -94,7 +94,7 @@ namespace Subterfuge.Remake.Core.GameEvents.Combat.CombatEvents
                 {
                     // Put specialists back on the sub.
                     _outpost.GetComponent<SpecialistManager>()
-                        .TransferSpecialistsById(_sub.GetComponent<SpecialistManager>(), specialistsTransferred.Select(it => it.GetId()).ToList(), timeMachine);
+                        .TransferSpecialistsById(_sub.GetComponent<SpecialistManager>(), specialistsTransferred.Select(it => it.GetSpecialistId().ToString()).ToList(), timeMachine);
                 }
             }
 
@@ -112,8 +112,8 @@ namespace Subterfuge.Remake.Core.GameEvents.Combat.CombatEvents
             var outpostDrillerCount = _outpost.GetComponent<DrillerCarrier>().GetDrillerCount();
             if (subDrillerCount <= 0 && outpostDrillerCount <= 0)
             {
-                // Attacker wins in the case of a tie
-                return _sub;
+                // Defender wins in the case of a tie
+                return _outpost;
             }
 
             if (subDrillerCount <= 0)

--- a/Core/SubterfugeCore/Core/Generation/MapGenerator.cs
+++ b/Core/SubterfugeCore/Core/Generation/MapGenerator.cs
@@ -34,6 +34,8 @@ namespace Subterfuge.Remake.Core.Generation
         /// </summary>
         private readonly MapConfiguration _mapConfiguration;
 
+        private readonly SeededRandom _random;
+
         /// <summary>
         /// Id Generator for outposts.
         /// </summary>
@@ -51,11 +53,13 @@ namespace Subterfuge.Remake.Core.Generation
         public MapGenerator(
             MapConfiguration mapConfiguration,
             List<Player> players,
-            TimeMachine timeMachine
+            TimeMachine timeMachine,
+            SeededRandom random
         ) {
-            this._players = players;
-            this._mapConfiguration = mapConfiguration;
+            _players = players;
+            _mapConfiguration = mapConfiguration;
             _timeMachine = timeMachine;
+            _random = random;
             
             if (players.Count <= 0)
             {
@@ -67,7 +71,7 @@ namespace Subterfuge.Remake.Core.Generation
                 throw new OutpostPerPlayerException("outpostsPerPlayer must be greater than or equal to one.");
             }
 
-            this._nameGenerator = new NameGenerator(Game.SeededRandom);
+            this._nameGenerator = new NameGenerator(_random);
 
             // Set the map size.
             int halfPlayers = (int)(Math.Floor(players.Count / 2.0));
@@ -84,7 +88,7 @@ namespace Subterfuge.Remake.Core.Generation
         private List<Outpost> TranslateOutposts(List<Outpost> outposts, RftVector translation)
         {
             // Generate a random rotation of 0/90/180/270 so the map doesn't appear to be tiled.
-            double rotation = Game.SeededRandom.NextRand(0, 3) * Math.PI / 2;
+            double rotation = _random.NextRand(0, 3) * Math.PI / 2;
 
             // List to store the newly translated outposts
             List<Outpost> translatedOutposts = new List<Outpost>();
@@ -141,8 +145,8 @@ namespace Subterfuge.Remake.Core.Generation
             while (playerOutposts.Count < _mapConfiguration.OutpostsPerPlayer + _mapConfiguration.DormantsPerPlayer)
             {
                 // calculate the new outposts location within allowable radius
-                var distance = Game.SeededRandom.NextDouble() * (_mapConfiguration.MaximumOutpostDistance - _mapConfiguration.MinimumOutpostDistance) + _mapConfiguration.MinimumOutpostDistance;
-                var direction = Game.SeededRandom.NextDouble() * Math.PI * 2;
+                var distance = _random.NextDouble() * (_mapConfiguration.MaximumOutpostDistance - _mapConfiguration.MinimumOutpostDistance) + _mapConfiguration.MinimumOutpostDistance;
+                var direction = _random.NextDouble() * Math.PI * 2;
 
                 // Determine the type of outpost that is generated
                 OutpostType[] validTypes =
@@ -151,7 +155,7 @@ namespace Subterfuge.Remake.Core.Generation
                     OutpostType.Generator,
                     OutpostType.Watchtower,
                 };
-                OutpostType type = validTypes[Game.SeededRandom.NextRand(0, 3)];
+                OutpostType type = validTypes[_random.NextRand(0, 3)];
 
                 //convert distance & direction into vector X and Y
                 var x = Convert.ToInt32(Math.Cos(direction) * distance);

--- a/Core/SubterfugeCore/Core/Players/Player.cs
+++ b/Core/SubterfugeCore/Core/Players/Player.cs
@@ -59,18 +59,6 @@ namespace Subterfuge.Remake.Core.Players
             this._isEliminated = false;
             this.CurrencyManager = new CurrencyManager();
         }
-        
-        public Player(
-            SimpleUser playerInstance,
-            List<SpecialistTypeId> specialistPool
-        ) {
-            this.PlayerInstance = playerInstance;
-            this._numMinesBuilt = 0;
-            this._neptunium = 0;
-            this._isEliminated = false;
-            this.CurrencyManager = new CurrencyManager();
-            this.SpecialistPool = new SpecialistPool(this, Game.SeededRandom, specialistPool);
-        }
 
         /// <summary>
         /// Gets the player's id

--- a/Core/SubterfugeCore/Core/Timing/SeededRandom.cs
+++ b/Core/SubterfugeCore/Core/Timing/SeededRandom.cs
@@ -12,15 +12,6 @@ namespace Subterfuge.Remake.Core.Timing
         private int _currentRand;
 
         /// <summary>
-        /// Seeded random constructor.
-        /// </summary>
-        public SeededRandom()
-        {
-            this._generator = new Random(Game.GameConfiguration.MapConfiguration.Seed);
-            this._currentRand = 0;
-        }
-        
-        /// <summary>
         /// Only needed for testing
         /// </summary>
         /// <param name="seed">The seed to generate random numbers from</param>

--- a/Core/SubterfugeCoreTest/Core/Combat/CombatTest.cs
+++ b/Core/SubterfugeCoreTest/Core/Combat/CombatTest.cs
@@ -1,0 +1,347 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Subterfuge.Remake.Api.Network;
+using Subterfuge.Remake.Core;
+using Subterfuge.Remake.Core.Entities.Components;
+using Subterfuge.Remake.Core.Entities.Positions;
+using Subterfuge.Remake.Core.Entities.Specialists;
+using Subterfuge.Remake.Core.Entities.Specialists.Heroes;
+using Subterfuge.Remake.Core.GameEvents.PlayerTriggeredEvents;
+using Subterfuge.Remake.Core.Players;
+using Subterfuge.Remake.Core.Timing;
+using Subterfuge.Remake.Core.Topologies;
+
+namespace Subterfuge.Remake.Test.Core.Combat
+{
+	[TestClass]
+    public class CombatTest
+    {
+
+	    private Game game = Game.Bare();
+	    private Player attackingPlayer;
+	    private Outpost attackingOutpost;
+	        
+	    private Player defendingPlayer;
+	    private Outpost defendingOutpost;
+	    
+	    
+        [TestInitialize]
+        public void Setup()
+        {
+	        game = Game.Bare();
+	        attackingPlayer = new Player(new SimpleUser() { Id = "1", Username = "Attacker" });
+	        attackingOutpost = new Generator("1", new RftVector(0, 0), attackingPlayer, game.TimeMachine);
+		        
+	        defendingPlayer = new Player(new SimpleUser() { Id = "2", Username = "Defender" });
+	        defendingOutpost = new Generator("2", new RftVector(0, 1), defendingPlayer, game.TimeMachine);
+	        game.TimeMachine.GetState().GetOutposts().AddRange(new List<Outpost>() { attackingOutpost, defendingOutpost });
+	        
+        	Assert.AreEqual(2, game.TimeMachine.GetState().GetOutposts().Count);
+        	Assert.AreEqual(2, game.TimeMachine.GetState().GetPlayers().Count);
+        }
+        
+	    [TestMethod]
+	    public void TestFailingDrillerCombat()
+	    {
+		    SetupDefence(50, 0, new List<SpecialistTypeId>());
+		    Attack(30, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+	    }
+
+	    [TestMethod]
+	    public void TestSuccessfulDrillerCombat()
+	    {
+		    SetupDefence(50, 0, new List<SpecialistTypeId>());
+		    Attack(60, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 10);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 50);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 60);
+	    }
+	    
+	    [TestMethod]
+	    public void TestAttackFailsIfTie()
+	    {
+		    SetupDefence(50, 0, new List<SpecialistTypeId>());
+		    Attack(50, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 0);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 50);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 50);
+	    }
+	    
+	    [TestMethod]
+	    public void TestDrillersAttackingLargerShields()
+	    {
+		    SetupDefence(20, 50, new List<SpecialistTypeId>());
+		    Attack(20, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 30);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 50);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 20);
+	    }
+	    
+	    [TestMethod]
+	    public void TestAttackDrainingAllShieldsButNotDrillers()
+	    {
+		    SetupDefence(20, 50, new List<SpecialistTypeId>());
+		    Attack(50, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 0);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 50);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 50);
+	    }
+	    
+	    [TestMethod]
+	    public void TestSuccessfulAttackAgainstShields()
+	    {
+		    SetupDefence(20, 50, new List<SpecialistTypeId>());
+		    Attack(71, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 1);
+		    AssertOutpostShields(defendingOutpost, 0);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 50);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 71);
+	    }
+	    
+	    [TestMethod]
+	    public void TestAttackingWithInfiltrator()
+	    {
+		    SetupDefence(20, 50, new List<SpecialistTypeId>());
+		    Attack(10, new List<SpecialistTypeId>() { SpecialistTypeId.Infiltrator });
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 50 - 10 - 15);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    AssertOutpostShields(defendingOutpost, 50);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 10);
+	    }
+	    
+	    [TestMethod]
+	    public void CanBustShieldsWithInfiltrator()
+	    {
+		    SetupDefence(0, 15, new List<SpecialistTypeId>());
+		    Attack(10, new List<SpecialistTypeId>() { SpecialistTypeId.Infiltrator });
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 10);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 0);
+		    AssertOutpostShields(defendingOutpost, 15);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 10);
+	    }
+	    
+	    [TestMethod]
+	    public void MartyrExplodesOnCombat()
+	    {
+		    SetupDefence(900, 15, new List<SpecialistTypeId>() { SpecialistTypeId.Martyr });
+		    Attack(10, new List<SpecialistTypeId>());
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 0);
+		    Assert.AreEqual(defendingOutpost.GetComponent<DrillerCarrier>().IsDestroyed(), true);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    Assert.AreEqual(attackingOutpost.GetComponent<DrillerCarrier>().IsDestroyed(), true);
+		    
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 900);
+		    AssertOutpostShields(defendingOutpost, 15);
+		    Assert.AreEqual(defendingOutpost.GetComponent<DrillerCarrier>().IsDestroyed(), false);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 10);
+		    Assert.AreEqual(attackingOutpost.GetComponent<DrillerCarrier>().IsDestroyed(), false);
+	    }
+	    
+	    [TestMethod]
+	    public void TheifStealsDrillersOnCombat()
+	    {
+		    SetupDefence(100, 0, new List<SpecialistTypeId>());
+		    Attack(100, new List<SpecialistTypeId>() { SpecialistTypeId.Theif });
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, attackingPlayer);
+		    // Steal 10 so enemy loses 10, we gain 10 = 90 vs. 110
+		    AssertOutpostDrillers(defendingOutpost, 20);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 100);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 100);
+	    }
+	    
+	    [TestMethod]
+	    public void VeteranDestroysDrillersOnCombat()
+	    {
+		    SetupDefence(100, 0, new List<SpecialistTypeId>());
+		    Attack(100, new List<SpecialistTypeId>() { SpecialistTypeId.Veteran });
+		    
+		    AssertOutpostOwnedBy(defendingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 10);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 0);
+		    
+		    game.TimeMachine.GoTo(new GameTick(0));
+		    AssertOutpostOwnedBy(defendingOutpost, defendingPlayer);
+		    AssertOutpostDrillers(defendingOutpost, 100);
+		    
+		    AssertOutpostOwnedBy(attackingOutpost, attackingPlayer);
+		    AssertOutpostDrillers(attackingOutpost, 100);
+	    }
+
+	    private void SetupDefence(
+		    int drillerCount = 10,
+		    int shieldCount = 0,
+		    List<SpecialistTypeId>? defendingSpecialists = null
+	    )
+	    {
+		    defendingOutpost.GetComponent<ShieldManager>().SetShieldCapacity(shieldCount);
+		    defendingOutpost.GetComponent<ShieldManager>().SetShields(shieldCount);
+		    defendingOutpost.GetComponent<DrillerCarrier>().SetDrillerCount(drillerCount);
+		    
+		    defendingOutpost.GetComponent<SpecialistManager>().AllowHireFromLocation();
+		    defendingSpecialists?.ForEach(spec =>
+		    {
+			    defendingOutpost.GetComponent<SpecialistManager>().HireSpecialist(
+				    SpecialistFactory.CreateSpecialist(spec, 1, defendingPlayer), game.TimeMachine);
+		    });
+	    }
+	    
+	    private void Attack(
+		    int drillerCount = 10,
+		    List<SpecialistTypeId> attackingSpecialists = null
+	    )
+	    {
+		    attackingOutpost.GetComponent<DrillerCarrier>().SetDrillerCount(drillerCount);
+		    
+		    attackingOutpost.GetComponent<SpecialistManager>().AllowHireFromLocation();
+		    attackingSpecialists?.ForEach(spec =>
+		    {
+			    attackingOutpost.GetComponent<SpecialistManager>().HireSpecialist(
+				    SpecialistFactory.CreateSpecialist(spec, 1, attackingPlayer), game.TimeMachine);
+		    });
+
+		    var launchEventData = new LaunchEventData()
+		    {
+			    DestinationId = "2",
+			    DrillerCount = drillerCount,
+			    SourceId = "1",
+			    SpecialistIds = attackingSpecialists?.ConvertAll(it => it.ToString())
+		    };
+		    var launchEvent = new LaunchEvent(new GameRoomEvent()
+		    {
+			    GameEventData = new GameEventData()
+			    {
+				    OccursAtTick = 1,
+				    EventDataType = EventDataType.LaunchEventData,
+				    SerializedEventData = JsonConvert.SerializeObject(launchEventData),
+			    },
+			    Id = "asdf",
+			    IssuedBy = attackingPlayer.PlayerInstance,
+			    RoomId = "1",
+			    TimeIssued = DateTime.UtcNow,
+		    });
+		    game.TimeMachine.AddEvent(launchEvent);
+		    game.TimeMachine.GoTo(launchEvent);
+		    game.TimeMachine.Advance(1);
+	    }
+
+	    private void AssertOutpostOwnedBy(Outpost outpost, Player owner)
+	    {
+		    Assert.AreEqual(owner.PlayerInstance.Username, outpost.GetComponent<DrillerCarrier>().GetOwner().PlayerInstance.Username);
+	    }
+
+	    private void AssertOutpostDrillers(Outpost outpost, int expectedDrillers)
+	    {
+		    Assert.AreEqual(expectedDrillers, outpost.GetComponent<DrillerCarrier>().GetDrillerCount());
+	    }
+	    
+	    private void AssertOutpostShields(Outpost outpost, int expectedShields)
+	    {
+		    Assert.AreEqual(expectedShields, outpost.GetComponent<ShieldManager>().GetShields());
+	    }
+    }
+}

--- a/Core/SubterfugeCoreTest/Core/Components/SpecialistManagerTest.cs
+++ b/Core/SubterfugeCoreTest/Core/Components/SpecialistManagerTest.cs
@@ -203,7 +203,7 @@ namespace Subterfuge.Remake.Test.Core.Components
             var specialist = new NoOpSpecialist(playerOne);
             bool removeResult = _mockEntity.Object.GetComponent<SpecialistManager>().TransferSpecialistsById(
                 _mockSecondEntity.Object.GetComponent<SpecialistManager>(), 
-                new List<string>() { specialist.GetId() },
+                new List<string>() { specialist.GetSpecialistId().ToString() },
                 _timeMachine
             );
             Assert.IsTrue(removeResult);
@@ -387,7 +387,7 @@ namespace Subterfuge.Remake.Test.Core.Components
             Assert.IsTrue(_mockEntity.Object.GetComponent<SpecialistManager>().GetSpecialists().Contains(specialistOne));
             Assert.IsTrue(_mockEntity.Object.GetComponent<SpecialistManager>().GetSpecialists().Contains(specialistTwo));
 
-            var listOfIds = specialists.Select(it => it.GetId()).ToList();
+            var listOfIds = specialists.Select(it => it.GetSpecialistId().ToString()).ToList();
 
             var transferResult = _mockEntity.Object.GetComponent<SpecialistManager>()
                 .TransferSpecialistsById(_mockSecondEntity.Object.GetComponent<SpecialistManager>(), listOfIds, _timeMachine);
@@ -428,7 +428,7 @@ namespace Subterfuge.Remake.Test.Core.Components
             Assert.IsTrue(_mockEntity.Object.GetComponent<SpecialistManager>().GetSpecialists().Contains(specialistOne));
             Assert.IsTrue(_mockEntity.Object.GetComponent<SpecialistManager>().GetSpecialists().Contains(specialistTwo));
 
-            var listOfIds = specialists.Select(it => it.GetId()).ToList();
+            var listOfIds = specialists.Select(it => it.GetSpecialistId().ToString()).ToList();
 
             var transferResult = _mockEntity.Object.GetComponent<SpecialistManager>()
                 .TransferSpecialistsById(_mockSecondEntity.Object.GetComponent<SpecialistManager>(), listOfIds, _timeMachine);

--- a/Core/SubterfugeCoreTest/DrillMineTest.cs
+++ b/Core/SubterfugeCoreTest/DrillMineTest.cs
@@ -35,7 +35,7 @@ namespace Subterfuge.Remake.Test
 			};
 			GameConfiguration config = testUtils.GetDefaultGameConfiguration(players);
 			config.MapConfiguration.OutpostsPerPlayer = 12;
-			_game = new Game(config);
+			_game = Game.FromGameConfiguration(config);
 			_tm = _game.TimeMachine;
 			_o1 = _tm.GetState().GetPlayerOutposts(_p)[0];
 			_o2 = _tm.GetState().GetPlayerOutposts(_p)[1];

--- a/Core/SubterfugeCoreTest/Factory.test.cs
+++ b/Core/SubterfugeCoreTest/Factory.test.cs
@@ -29,7 +29,7 @@ namespace Subterfuge.Remake.Test
 		{
 			GameConfiguration config = testUtils.GetDefaultGameConfiguration(players);
 			config.MapConfiguration.OutpostsPerPlayer = 10;
-			_game = new Game(config);
+			_game = Game.FromGameConfiguration(config);
 			_tm = _game.TimeMachine;
 			foreach (Outpost o in _tm.GetState().GetPlayerOutposts(players[0]))
 			{

--- a/Core/SubterfugeCoreTest/GameTest.cs
+++ b/Core/SubterfugeCoreTest/GameTest.cs
@@ -38,6 +38,7 @@ namespace Subterfuge.Remake.Test
 		public void GameCanLoadFromConfiguration()
 		{
 			GameConfiguration config = new GameConfiguration();
+			config.PlayersInLobby = new List<User>() { new SimpleUser() { Id = "1", Username = "Test" }.ToUser() };
 			Game game = Game.FromGameConfiguration(config);
 			Assert.AreEqual(game.TimeMachine.GetState().GetPlayers().Count, config.PlayersInLobby.Count);
 		}
@@ -46,6 +47,7 @@ namespace Subterfuge.Remake.Test
 		public void GameCreatedFromConfigGeneratesMap()
 		{
 			GameConfiguration config = new GameConfiguration();
+			config.PlayersInLobby = new List<User>() { new SimpleUser() { Id = "1", Username = "Test" }.ToUser() };
 			Game game = Game.FromGameConfiguration(config);
 			Assert.AreEqual(game.TimeMachine.GetState().GetPlayers().Count, config.PlayersInLobby.Count);
 			Assert.IsTrue(game.TimeMachine.GetState().GetOutposts().Count > 0);

--- a/Core/SubterfugeCoreTest/GameTest.cs
+++ b/Core/SubterfugeCoreTest/GameTest.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Subterfuge.Remake.Api.Network;
+using Subterfuge.Remake.Core;
+using Subterfuge.Remake.Core.Entities;
+using Subterfuge.Remake.Core.Entities.Components;
+using Subterfuge.Remake.Core.Entities.Positions;
+using Subterfuge.Remake.Core.GameEvents.PlayerTriggeredEvents;
+using Subterfuge.Remake.Core.Players;
+using Subterfuge.Remake.Core.Timing;
+using Subterfuge.Remake.Core.Topologies;
+
+namespace Subterfuge.Remake.Test
+{
+	
+	[TestClass]
+	public class GameTest
+	{
+		[TestMethod]
+		public void BareGameDoesNotGenerateMap()
+		{
+			Game game = Game.Bare();
+			Assert.AreEqual(game.TimeMachine.GetState().GetOutposts().Count, 0);
+		}
+		
+		[TestMethod]
+		public void CanAddOutpostsToBareGame()
+		{
+			Game game = Game.Bare();
+			Assert.AreEqual(game.TimeMachine.GetState().GetOutposts().Count, 0);
+			game.TimeMachine.GetState().GetOutposts().Add(new Factory("1", new RftVector(0, 0), game.TimeMachine));
+			Assert.AreEqual(game.TimeMachine.GetState().GetOutposts().Count, 1);
+		}
+
+		[TestMethod]
+		public void GameCanLoadFromConfiguration()
+		{
+			GameConfiguration config = new GameConfiguration();
+			Game game = Game.FromGameConfiguration(config);
+			Assert.AreEqual(game.TimeMachine.GetState().GetPlayers().Count, config.PlayersInLobby.Count);
+		}
+
+		[TestMethod]
+		public void GameCreatedFromConfigGeneratesMap()
+		{
+			GameConfiguration config = new GameConfiguration();
+			Game game = Game.FromGameConfiguration(config);
+			Assert.AreEqual(game.TimeMachine.GetState().GetPlayers().Count, config.PlayersInLobby.Count);
+			Assert.IsTrue(game.TimeMachine.GetState().GetOutposts().Count > 0);
+		}
+	}
+}

--- a/Core/SubterfugeCoreTest/GameTick.test.cs
+++ b/Core/SubterfugeCoreTest/GameTick.test.cs
@@ -24,7 +24,7 @@ namespace Subterfuge.Remake.Test
             _tickNumber = 0;
             _tick = new GameTick(_tickNumber);
             GameConfiguration config = testUtils.GetDefaultGameConfiguration(new List<Player>{ new Player(new SimpleUser() { Id = "1" }) });
-            new Game(config);
+            Game.FromGameConfiguration(config);
         }
 
         [TestMethod]

--- a/Core/SubterfugeCoreTest/LaunchEvent.test.cs
+++ b/Core/SubterfugeCoreTest/LaunchEvent.test.cs
@@ -32,7 +32,7 @@ namespace Subterfuge.Remake.Test
         public void Setup()
         {
             GameConfiguration config = testUtils.GetDefaultGameConfiguration(players);
-            _game = new Game(config);
+            _game = Game.FromGameConfiguration(config);
         }
 
         [TestMethod]

--- a/Core/SubterfugeCoreTest/MapGenerator.test.cs
+++ b/Core/SubterfugeCoreTest/MapGenerator.test.cs
@@ -17,6 +17,7 @@ namespace Subterfuge.Remake.Test
     {
         private readonly TestUtils _testUtils = new TestUtils();
         private TimeMachine _timeMachine;
+        private SeededRandom random = new SeededRandom(1234);
         
         List<Player> players = new List<Player>
         {
@@ -31,7 +32,7 @@ namespace Subterfuge.Remake.Test
         {
             _timeMachine = new TimeMachine(new GameState(players));
             GameConfiguration config = new TestUtils().GetDefaultGameConfiguration(players);
-            new Game(config);
+            Game.FromGameConfiguration(config);
         }
 
         [TestMethod]
@@ -47,7 +48,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
 
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             Assert.IsNotNull(generator);
         }
 
@@ -63,7 +64,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
             Assert.AreEqual(config.PlayersInLobby.Count * (config.MapConfiguration.OutpostsPerPlayer + config.MapConfiguration.DormantsPerPlayer), generatedOutposts.Count);
         }
@@ -80,7 +81,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             List<Player> playersGenerated = new List<Player>();
@@ -106,7 +107,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             Dictionary<Player, int> outpostCounts = new Dictionary<Player, int>();
@@ -141,7 +142,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
 
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             // Loop through all unowned outpost and verify that the driller count is 0 for each
@@ -163,7 +164,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
 
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             // Advance the time forward until next shield production
@@ -188,7 +189,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
 
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             // Advance the time forward until next production
@@ -213,7 +214,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 5;
             config.MapConfiguration.OutpostsPerPlayer = 7;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
 
             Dictionary<Player, int> queenCounts = new Dictionary<Player, int>();
@@ -248,7 +249,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 0;
             config.MapConfiguration.OutpostsPerPlayer = 7;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
             
             // Ensure all 7 outposts were generated on top of each other.
@@ -274,7 +275,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 0;
             config.MapConfiguration.OutpostsPerPlayer = 7;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
             
             // Ensure all 7 outposts were generated on top of each other.
@@ -288,7 +289,7 @@ namespace Subterfuge.Remake.Test
         {
             List<Player> players = new List<Player>();
             GameConfiguration config = _testUtils.GetDefaultGameConfiguration(players);
-            new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             
         }
         
@@ -299,7 +300,7 @@ namespace Subterfuge.Remake.Test
             // List<Player> players = new List<Player> { new Player("1") };
             GameConfiguration config = _testUtils.GetDefaultGameConfiguration(players);
             config.MapConfiguration.OutpostsPerPlayer = 0;
-            new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             
         }
         
@@ -317,7 +318,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 0;
             config.MapConfiguration.OutpostsPerPlayer = 1;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
             
             // Ensure all 7 outposts were generated
@@ -347,7 +348,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 1;
             config.MapConfiguration.OutpostsPerPlayer = 2;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
             
             // Ensure the distance between outposts is over 199.
@@ -372,7 +373,7 @@ namespace Subterfuge.Remake.Test
             config.MapConfiguration.MinimumOutpostDistance = 20;
             config.MapConfiguration.OutpostsPerPlayer = 3;
             
-            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine);
+            MapGenerator generator = new MapGenerator(config.MapConfiguration, players, _timeMachine, random);
             List<Outpost> generatedOutposts = generator.GenerateMap();
             
             Assert.AreEqual(generatedOutposts.Select(x => x.GetComponent<IdentityManager>().GetName()).Distinct().Count(), generatedOutposts.Count);   

--- a/Core/SubterfugeCoreTest/Outpost.test.cs
+++ b/Core/SubterfugeCoreTest/Outpost.test.cs
@@ -137,7 +137,7 @@ namespace Subterfuge.Remake.Test
         [TestMethod]
         public void CanLaunchSubs()
         {
-            Game game = new Game(_testUtils.GetDefaultGameConfiguration(_playersInGame));
+            Game game = Game.FromGameConfiguration(_testUtils.GetDefaultGameConfiguration(_playersInGame));
             game.TimeMachine.GetState().GetOutposts().Add(_outpost);
             game.TimeMachine.GetState().GetOutposts().Add(_outpost2);
 
@@ -167,7 +167,7 @@ namespace Subterfuge.Remake.Test
         [TestMethod]
         public void CanUndoSubLaunch()
         {
-            Game game = new Game(_testUtils.GetDefaultGameConfiguration(_playersInGame));
+            Game game = Game.FromGameConfiguration(_testUtils.GetDefaultGameConfiguration(_playersInGame));
             game.TimeMachine.GetState().GetOutposts().Add(_outpost);
             game.TimeMachine.GetState().GetOutposts().Add(_outpost2);
 

--- a/Core/SubterfugeCoreTest/TimeMachine.test.cs
+++ b/Core/SubterfugeCoreTest/TimeMachine.test.cs
@@ -27,7 +27,7 @@ namespace Subterfuge.Remake.Test
         [TestInitialize]
         public void Setup()
         {
-            _game = new Game(testUtils.GetDefaultGameConfiguration(new List<Player> { player }));
+            _game = Game.FromGameConfiguration(testUtils.GetDefaultGameConfiguration(new List<Player> { player }));
 
         }
 


### PR DESCRIPTION
# Description
Allows 'Bare' games to be created which bypasses map generation. This can be useful for puzzle modes, or allowing custom maps in the future, or even debugging on the client so I can place outposts, and test various combat outcomes.

Additionally, add unit tests for various combat scenarios to ensure that specialist combats are working as intended.